### PR TITLE
Update site for Zola 0.22

### DIFF
--- a/.github/workflows/zola-website.yml
+++ b/.github/workflows/zola-website.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Zola
         uses: taiki-e/install-action@v2
         with:
-          tool: zola@0.19
+          tool: zola@0.22.1
 
       - name: Inject Google Analytics
         shell: pwsh

--- a/config.toml
+++ b/config.toml
@@ -24,13 +24,14 @@ taxonomies = [
 ]
 
 [markdown]
-highlight_code = true
-highlight_theme = "one-dark"
 render_emoji = true
 external_links_target_blank = true
 external_links_no_follow = true
 external_links_no_referrer = true
 smart_punctuation = false
+
+[markdown.highlighting]
+theme = "one-dark-pro"
 
 # Configuration of the link checker.
 [link_checker]

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block head_extra %}
-{% if config.generate_feed %}
+{% if config.generate_feeds %}
 {% set feed_url = config.base_url ~ '/' ~ config.feed_filenames[0] %}
 <link rel="alternate" type="application/rss+xml" title="{{ config.title }} RSS Feed" href="{{ feed_url | safe }}" />
 {% endif %}


### PR DESCRIPTION
## Summary
- migrate site Markdown highlighting config to Zola 0.22 `[markdown.highlighting]` syntax
- update feed config references from `generate_feed` to `generate_feeds`
- update CI to install `zola@0.22.1`
- advance `themes/DeepThought` to `awakecoding` commit `0054dc6`, which applies the matching theme compatibility update

## Validation
- `zola build` from the parent site: creates 34 pages
- `zola build` from `themes/DeepThought`: creates 17 pages
- `./scripts/GenerateFeed.ps1` generated `public/feed.json`
- banner front matter extraction found 34 posts with 0 missing title/slug/banner fields

## Notes
- the theme demo Mapbox token was removed from the submodule config so GitHub push protection accepts the theme update